### PR TITLE
Package の Swift 6 対応（ワーニング対応も含む）

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -12,8 +12,7 @@ let package = Package(
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "FABoLLFlickableButton",
-            targets: [
-                "FABoLLFlickableButton"]),
+            targets: ["FABoLLFlickableButton"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -31,7 +30,7 @@ let package = Package(
             name: "FABoLLFlickableButtonTests",
             dependencies: ["FABoLLFlickableButton"]),
     ],
-    swiftLanguageVersions: [
-        .v5,
+    swiftLanguageModes: [
+        .v6,
     ]
 )

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # FABoLLFlickableButton
 
-[![FABoLL](https://custom-icon-badges.herokuapp.com/badge/license-FABoLL-8BB80A.svg?logo=law&logoColor=white)]()　[![iOS 16.0](https://custom-icon-badges.herokuapp.com/badge/iOS-16.0-007bff.svg?logo=apple&logoColor=white)]()　[![Xcode 15.3](https://custom-icon-badges.herokuapp.com/badge/Xcode-15.3-007bff.svg?logo=Xcode&logoColor=white)]()　[![Swift 5.9](https://custom-icon-badges.herokuapp.com/badge/Swift-5.9-df5c43.svg?logo=Swift&logoColor=white)]()
+[![FABoLL](https://custom-icon-badges.herokuapp.com/badge/license-FABoLL-8BB80A.svg?logo=law&logoColor=white)]()　
+[![iOS 16.0](https://custom-icon-badges.herokuapp.com/badge/iOS-16.0-007bff.svg?logo=apple&logoColor=white)]()　
+[![Xcode 16.2](https://custom-icon-badges.herokuapp.com/badge/Xcode-16.2-007bff.svg?logo=Xcode&logoColor=white)]()　
+[![Swift 6.0](https://custom-icon-badges.herokuapp.com/badge/Swift-6.0-df5c43.svg?logo=Swift&logoColor=white)]()
 
 You can add flick action to UIButton.  
 If you use `FABoLLFlickableButton`, you can receive callback from  swipe gestures.
@@ -31,13 +34,39 @@ right.backgroundColor = .blue
 right.clipsToBounds = true
 right.layer.cornerRadius = button.frame.size.width * 0.5
 
-/// Add flick actions
+// Add flick actions
 button.setFlickable(
     settings: FABoLLFlickableButtonSettings(
-        views: (up: up, left: left, down: down, right: right),
-        margins: (up: 5., left: 10, down: 5, right: 10),
-        animationDuration: nil
+        upView: up,
+        leftView: left,
+        downView: down,
+        rightView: right,
+        upMargin: 5,
+        downMargin: 5
     ),
+    callbackUp: {
+        print("up")
+    },
+    callbackLeft: {
+        print("left")
+    },
+    callbackDown: {
+        print("down")
+    },
+    callbackRight: {
+        print("right")
+    }
+)
+// OR
+var settings: FABoLLFlickableButtonSettings = .init()
+settings.update(\.upView, up)
+settings.update(\.leftView, left)
+settings.update(\.downView, down)
+settings.update(\.rightView, right)
+settings.update(\.upMargin, 5)
+settings.update(\.downMargin, 5)
+button.setFlickable(
+    settings: settings,
     callbackUp: {
         print("up")
     },

--- a/Sources/FABoLLFlickableButton/FABoLLFlickableButton.swift
+++ b/Sources/FABoLLFlickableButton/FABoLLFlickableButton.swift
@@ -1,95 +1,38 @@
 //
-//  FABoLLFlickableButton.swift
-//
-//  Created by Masakiyo Tachikawa on 2020/02/21.
-//  Copyright © 2020 FABoLL. All rights reserved.
-//
-//  Copyright 2020 Masakiyo Tachikawa
-//
-//  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to deal
-//  in the Software without restriction, including without limitation the rights
-//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//  copies of the Software, and to permit persons to whom the Software is
-//  furnished to do so, subject to the following conditions:
-//
-//  The above copyright notice and this permission notice shall be included in
-//  all copies or substantial portions of the Software.
-//
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-//  THE SOFTWARE.
+//  FABoLLFlickableButton
 //
 //  © 2023 Masakiyo Tachikawa
 //
 
 import UIKit
 
-// MARK: - FABoLLFlickableButton
-
-/// Added top, bottom, left, right swipe action
 public class FABoLLFlickableButton: UIButton {
 
     // MARK: - typealias
 
     private typealias FlickableView = (view: UIView?, center: CGPoint, callback: (() -> Void)?)
 
-    // MARK: - enum
-
-    fileprivate enum PanDirection: Int, CaseIterable {
-
-        case none
-
-        case up
-
-        case left
-
-        case down
-
-        case right
-    }
-
     // MARK: - Properties
 
-    private var settings = FABoLLFlickableButtonSettings(
-        views: (
-            up: nil,
-            left: nil,
-            down: nil,
-            right: nil
-        ),
-        margins: nil,
-        animationDuration: nil
-    )
-
-    private var upCenter: CGPoint { CGPoint(x: center.x, y: center.y - frame.height - settings.margins.up) }
-
-    private var leftCenter: CGPoint { CGPoint(x: center.x - frame.width - settings.margins.left, y: center.y) }
-
-    private var downCenter: CGPoint { CGPoint(x: center.x, y: center.y + frame.height + settings.margins.up) }
-
-    private var rightCenter: CGPoint { CGPoint(x: center.x + frame.width + settings.margins.left, y: center.y) }
-
-    private var callbackUp: (() -> Void)?
-
-    private var callbackLeft: (() -> Void)?
-
-    private var callbackDown: (() -> Void)?
-
-    private var callbackRight: (() -> Void)?
-
+    private var settings: FABoLLFlickableButtonSettings = .init()
     private var panStart: CGPoint = .zero
 
-    private var showDuration: Double { settings.animationDuration.show }
+    private var callbackUp: (() -> Void)?
+    private var callbackLeft: (() -> Void)?
+    private var callbackDown: (() -> Void)?
+    private var callbackRight: (() -> Void)?
 
-    private var hideDuration: Double { settings.animationDuration.hide }
-
-    private var stayDuration: Double { settings.animationDuration.stay }
-
+    private var upView: UIView? { settings.upView }
+    private var leftView: UIView? { settings.leftView }
+    private var downView: UIView? { settings.downView }
+    private var rightView: UIView? { settings.rightView }
+    private var upCenter: CGPoint { .init(x: center.x, y: center.y - frame.height - settings.upMargin) }
+    private var leftCenter: CGPoint { .init(x: center.x - frame.width - settings.leftMargin, y: center.y) }
+    private var downCenter: CGPoint { .init(x: center.x, y: center.y + frame.height + settings.downMargin) }
+    private var rightCenter: CGPoint { .init(x: center.x + frame.width + settings.rightMargin, y: center.y) }
+    private var showDuration: Double { settings.showDuration }
+    private var hideDuration: Double { settings.hideDuration }
+    private var stayDuration: Double { settings.stayDuration }
 
     // MARK: - Conveniences
 
@@ -98,13 +41,13 @@ public class FABoLLFlickableButton: UIButton {
         case .none:
             (nil, center, nil)
         case .up:
-            (settings.views.up, upCenter, callbackUp)
+            (upView, upCenter, callbackUp)
         case .left:
-            (settings.views.left, leftCenter, callbackLeft)
+            (leftView, leftCenter, callbackLeft)
         case .down:
-            (settings.views.down, downCenter, callbackDown)
+            (downView, downCenter, callbackDown)
         case .right:
-            (settings.views.right, rightCenter, callbackRight)
+            (rightView, rightCenter, callbackRight)
         }
     }
 
@@ -117,10 +60,10 @@ public class FABoLLFlickableButton: UIButton {
     /// `settings` define is FABoLLFlickableButtonSettings.
     public func setFlickable(
         settings: FABoLLFlickableButtonSettings,
-        callbackUp: (() -> Void)?,
-        callbackLeft: (() -> Void)?,
-        callbackDown: (() -> Void)?,
-        callbackRight: (() -> Void)?
+        callbackUp: (() -> Void)? = nil,
+        callbackLeft: (() -> Void)? = nil,
+        callbackDown: (() -> Void)? = nil,
+        callbackRight: (() -> Void)? = nil
     ) {
         self.settings = settings
         self.callbackUp = callbackUp
@@ -133,10 +76,10 @@ public class FABoLLFlickableButton: UIButton {
 
     private func setViews() {
         [
-            settings.views.up,
-            settings.views.left,
-            settings.views.down,
-            settings.views.right,
+            upView,
+            leftView,
+            downView,
+            rightView,
         ].forEach { view in
             guard let view else { return }
             view.isUserInteractionEnabled = false
@@ -166,9 +109,7 @@ public class FABoLLFlickableButton: UIButton {
 
     @objc private func swiped(_ gesture: UISwipeGestureRecognizer) {
         let direction: FABoLLFlickableButton.PanDirection = gesture.direction.panDirection
-        if direction == .none {
-            return
-        }
+        if direction == .none { return }
         let target: FlickableView = getTarget(direction)
         showFlickableView(target.view, target.center)
         target.callback?()
@@ -202,9 +143,7 @@ public class FABoLLFlickableButton: UIButton {
         if gesture.state == .changed {
             let point: CGPoint = gesture.location(in: self)
             let direction: FABoLLFlickableButton.PanDirection = getPanDirection(point)
-            if direction == .none {
-                return
-            }
+            if direction == .none { return }
             panShowFlickableView(direction)
             return
         }
@@ -249,10 +188,10 @@ public class FABoLLFlickableButton: UIButton {
     private func hideAllFlickableView() {
         UIView.animate(withDuration: hideDuration, delay: stayDuration, options: .curveEaseIn) {
             self.alpha = 1
-            self.settings.views.up?.alpha = 0
-            self.settings.views.left?.alpha = 0
-            self.settings.views.down?.alpha = 0
-            self.settings.views.right?.alpha = 0
+            self.upView?.alpha = 0
+            self.leftView?.alpha = 0
+            self.downView?.alpha = 0
+            self.rightView?.alpha = 0
         } completion: { _ in
             self.clipsToBounds = true
         }
@@ -269,8 +208,17 @@ public class FABoLLFlickableButton: UIButton {
     }
 }
 
-private extension UISwipeGestureRecognizer.Direction {
+private extension FABoLLFlickableButton {
+    enum PanDirection: Int, CaseIterable {
+        case none
+        case up
+        case left
+        case down
+        case right
+    }
+}
 
+private extension UISwipeGestureRecognizer.Direction {
     var panDirection: FABoLLFlickableButton.PanDirection {
         switch self {
         case .up:

--- a/Sources/FABoLLFlickableButton/FABoLLFlickableButtonSettings.swift
+++ b/Sources/FABoLLFlickableButton/FABoLLFlickableButtonSettings.swift
@@ -8,34 +8,57 @@ import UIKit
 
 // MARK: - FABoLLFlickableButtonSettings
 
-public struct FABoLLFlickableButtonSettings {
+public struct FABoLLFlickableButtonSettings: Sendable {
 
     // MARK: - Properties
 
-    /// Display view when flicked
-    let views: (up: UIView?, left: UIView?, down: UIView?, right: UIView?)
-    ///  Margin between base view and flicked view
-    let margins: (up: CGFloat, left: CGFloat, down: CGFloat, right: CGFloat)
+    public private(set) var upView: UIView?
+    public private(set) var leftView: UIView?
+    public private(set) var downView: UIView?
+    public private(set) var rightView: UIView?
 
-    let animationDuration: (show: Double, stay: Double, hide: Double)
+    public private(set) var upMargin: CGFloat
+    public private(set) var leftMargin: CGFloat
+    public private(set) var downMargin: CGFloat
+    public private(set) var rightMargin: CGFloat
+
+    public private(set) var showDuration: Double
+    public private(set) var stayDuration: Double
+    public private(set) var hideDuration: Double
 
     // MARK: - Life cycle
 
     public init(
-        views: (up: UIView?, left: UIView?, down: UIView?, right: UIView?),
-        margins: (up: CGFloat, left: CGFloat, down: CGFloat, right: CGFloat)?,
-        animationDuration: (show: Double, stay: Double, hide: Double)?
+        upView: UIView? = nil,
+        leftView: UIView? = nil,
+        downView: UIView? = nil,
+        rightView: UIView? = nil,
+        upMargin: CGFloat = 10,
+        leftMargin: CGFloat = 10,
+        downMargin: CGFloat = 10,
+        rightMargin: CGFloat = 10,
+        showDuration: Double = 0.1,
+        stayDuration: Double = 0.5,
+        hideDuration: Double = 0.1
     ) {
-        self.views = views
-        if let margins {
-            self.margins = margins
-        } else {
-            self.margins = (up: 0, left: 0, down: 0, right: 0)
+        self.upView = upView
+        self.leftView = leftView
+        self.downView = downView
+        self.rightView = rightView
+        self.upMargin = upMargin
+        self.leftMargin = leftMargin
+        self.downMargin = downMargin
+        self.rightMargin = rightMargin
+        self.showDuration = showDuration
+        self.stayDuration = stayDuration
+        self.hideDuration = hideDuration
+    }
+
+    public mutating func update<T>(_ key: KeyPath<Self, T>, _ value: T) {
+        guard let writableKey = key as? WritableKeyPath<Self, T> else {
+            assertionFailure("KeyPath変換で問題発生")
+            return
         }
-        if let animationDuration {
-            self.animationDuration = animationDuration
-        } else {
-            self.animationDuration = (show: 0.1, stay: 0.5, hide: 0.1)
-        }
+        self[keyPath: writableKey] = value
     }
 }

--- a/Tests/FABoLLFlickableButtonTests/FABoLLFlickableButtonTest.swift
+++ b/Tests/FABoLLFlickableButtonTests/FABoLLFlickableButtonTest.swift
@@ -1,22 +1,22 @@
+//
+//  FABoLLFlickableButtonTest
+//
+//  © 2023 Masakiyo Tachikawa
+//
+
+import Testing
 import XCTest
 @testable import FABoLLFlickableButton
 
-final class FABoLLFlickableButtonTests: XCTestCase {
-
-    // MARK: - Static Properties
-
-    static var allTests = [
-        ("testAllDirectionsAdd", testAllDirectionsAdd),
-    ]
-
-    private static let ButtonSize: CGSize = .init(width: 50, height: 50)
-
-    // MARK: - Properties
+@MainActor
+struct FABoLLFlickableButtonTest {
 
     private let base: UIView = .init(frame: UIScreen.main.bounds)
-
     private let flickableButton: FABoLLFlickableButton = .init(
-        frame: CGRect(origin: .zero, size: FABoLLFlickableButtonTests.ButtonSize)
+        frame: CGRect(
+            origin: .zero,
+            size: .init(width: 50, height: 50)
+        )
     )
 
     private var up: UILabel {
@@ -56,27 +56,23 @@ final class FABoLLFlickableButtonTests: XCTestCase {
         return right
     }
 
-    // MARK: - tests
 
-    override func setUp() {
-        super.setUp()
+    @Test func test() async throws {
         base.addSubview(flickableButton)
         flickableButton.center = base.center
-    }
-
-    func testAllDirectionsAdd() {
-        flickableButton.setFlickable(
-            settings: FABoLLFlickableButtonSettings(
-                views: (up: up, left: left, down: down, right: right),
-                margins: (up: 10, left: 10, down: 10, right: 10),
-                animationDuration: nil
-            ),
-            callbackUp: nil,
-            callbackLeft: nil,
-            callbackDown: nil,
-            callbackRight: nil
+        var settings: FABoLLFlickableButtonSettings = .init(
+            upView: up,
+            leftView: left,
+            downView: down,
+            rightView: right,
+            upMargin: 10,
+            leftMargin: 10,
+            downMargin: 10,
+            rightMargin: 10
         )
-        let titles: [String] = [
+        // All
+        flickableButton.setFlickable(settings: settings)
+        var titles: [String] = [
             "UP",
             "⚡️",
             "Left",
@@ -88,21 +84,11 @@ final class FABoLLFlickableButtonTests: XCTestCase {
             XCTAssertNotNil(label.text)
             XCTAssertTrue(titles.contains(label.text!))
         }
-    }
-
-    func testUpAndDownDirectionsAdd() {
-        flickableButton.setFlickable(
-            settings: FABoLLFlickableButtonSettings(
-                views: (up: up, left: nil, down: down, right: nil),
-                margins: (up: 10, left: 10, down: 10, right: 10),
-                animationDuration: nil
-            ),
-            callbackUp: nil,
-            callbackLeft: nil,
-            callbackDown: nil,
-            callbackRight: nil
-        )
-        let titles: [String] = [
+        // Up and Down
+        settings.update(\.leftView, nil)
+        settings.update(\.rightView, nil)
+        flickableButton.setFlickable(settings: settings)
+        titles = [
             "UP",
             "⚡️",
         ]
@@ -112,21 +98,13 @@ final class FABoLLFlickableButtonTests: XCTestCase {
             XCTAssertNotNil(label.text)
             XCTAssertTrue(titles.contains(label.text!))
         }
-    }
-
-    func testLeftAndRightDirectionsAdd() {
-        flickableButton.setFlickable(
-            settings: FABoLLFlickableButtonSettings(
-                views: (up: nil, left: left, down: nil, right: right),
-                margins: nil,
-                animationDuration: nil
-            ),
-            callbackUp: nil,
-            callbackLeft: nil,
-            callbackDown: nil,
-            callbackRight: nil
-        )
-        let titles: [String] = [
+        // Left and Right
+        settings.update(\.upView, nil)
+        settings.update(\.downView, nil)
+        settings.update(\.leftView, left)
+        settings.update(\.rightView, right)
+        flickableButton.setFlickable(settings: settings)
+        titles = [
             "Left",
             "✋",
         ]
@@ -136,20 +114,10 @@ final class FABoLLFlickableButtonTests: XCTestCase {
             XCTAssertNotNil(label.text)
             XCTAssertTrue(titles.contains(label.text!))
         }
-    }
-
-    func testAllDirectionsNill() {
-        flickableButton.setFlickable(
-            settings: FABoLLFlickableButtonSettings(
-                views: (up: nil, left: nil, down: nil, right: nil),
-                margins: nil,
-                animationDuration: nil
-            ),
-            callbackUp: nil,
-            callbackLeft: nil,
-            callbackDown: nil,
-            callbackRight: nil
-        )
+        // None
+        settings.update(\.leftView, nil)
+        settings.update(\.rightView, nil)
+        flickableButton.setFlickable(settings: settings)
         XCTAssertEqual(base.subviews.count, 1)
         base.subviews.forEach { view in
             if let _ = view as? UILabel {

--- a/Tests/FABoLLFlickableButtonTests/XCTestManifests.swift
+++ b/Tests/FABoLLFlickableButtonTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(FABoLLFlickableButtonTests.allTests),
-    ]
-}
-#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,7 +1,0 @@
-import XCTest
-
-import FABoLLFlickableButtonTests
-
-var tests = [XCTestCaseEntry]()
-tests += FABoLLFlickableButtonTests.allTests()
-XCTMain(tests)


### PR DESCRIPTION
## チケットへのリンク

なし

## やったこと

- Package を Swift 6 に変更
- FABoLLFlickableButtonSettings を Sendable に変更してリファクタ
- FABoLLFlickableButton を FABoLLFlickableButtonSettings の修正に合わせてリファクタ
- テストを Testing を利用するようにリファクタ
- README を更新

## やらないこと

n/a

## 変わること

### できるようになること

n/a

### できなくなること

n/a

## 動作確認

demo プロジェクトで動作確認。

## その他

なし